### PR TITLE
Example of customization: left prompt only, $ as the symbol

### DIFF
--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -2,7 +2,6 @@
 # 
 # - Git info in left prompt
 # - Removed user name
-# - Added blank line before prompt
 # - $ as the symbol
 # 
 # It looks like this:
@@ -515,7 +514,7 @@ agkozak_zsh_theme() {
     unset zle_bracketed_paste
   else
     if _agkozak_has_colors; then
-      PS1=$'${AGKOZAK_PROMPT_WHITESPACE}%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b%F{${AGKOZAK_COLORS_BRANCH_STATUS}}%3v%f${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
+      PS1=$'%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b%F{${AGKOZAK_COLORS_BRANCH_STATUS}}%3v%f${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
     else
       PS1=$'%(?..(%?%) )%(!.%S.)%n%1v%(!.%s.) %2v${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
       RPS1='%3v'

--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -1,3 +1,15 @@
+# Fork of https://github.com/agkozak/agkozak-zsh-theme with these modifications:
+# 
+# - Git info in left prompt
+# - Removed user name
+# - Added blank line before prompt
+# 
+# It looks like this:
+#
+#     .../dev/project (master)
+#     % 
+#
+
 #              _                 _
 #   __ _  __ _| | _____ ______ _| | __
 #  / _` |/ _` | |/ / _ \_  / _` | |/ /
@@ -502,8 +514,7 @@ agkozak_zsh_theme() {
     unset zle_bracketed_paste
   else
     if _agkozak_has_colors; then
-      PS1=$'%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%(!.%S%B.%B%F{${AGKOZAK_COLORS_USER_HOST}})%n%1v%(!.%b%s.%f%b) %B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
-      RPS1='%F{${AGKOZAK_COLORS_BRANCH_STATUS}}%3v%f'
+      PS1=$'${AGKOZAK_PROMPT_WHITESPACE}%(?..%B%F{${AGKOZAK_COLORS_EXIT_STATUS}}(%?%)%f%b )%B%F{${AGKOZAK_COLORS_PATH}}%2v%f%b%F{${AGKOZAK_COLORS_BRANCH_STATUS}}%3v%f${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
     else
       PS1=$'%(?..(%?%) )%(!.%S.)%n%1v%(!.%s.) %2v${AGKOZAK_PROMPT_WHITESPACE}$(_agkozak_vi_mode_indicator) '
       RPS1='%3v'

--- a/agkozak-zsh-theme.plugin.zsh
+++ b/agkozak-zsh-theme.plugin.zsh
@@ -3,11 +3,12 @@
 # - Git info in left prompt
 # - Removed user name
 # - Added blank line before prompt
+# - $ as the symbol
 # 
 # It looks like this:
 #
 #     .../dev/project (master)
-#     % 
+#     $ 
 #
 
 #              _                 _
@@ -186,7 +187,7 @@ _agkozak_branch_changes() {
 _agkozak_vi_mode_indicator() {
   case $KEYMAP in
     vicmd) print -n ':' ;;
-    *) print -n '%#' ;;
+    *) print -n '%(!.#.$)' ;;
   esac
 }
 


### PR DESCRIPTION
**UPDATE:** the customization via forking is no longer necessary, see https://github.com/agkozak/agkozak-zsh-prompt/pull/9#issuecomment-408717771.

---

First of all, _thank you_ for this prompt. On Mac, I use the Pure prompt but that doesn't work on Windows due to the `zsh/zpty` issue in `zsh-async` (https://github.com/mafredri/zsh-async/issues/26). Yours is the only one I found so far that works in MSYS2 and is asynchronous, which is awesome.

Now, I prefer the simpler style of `pure` so I've customized your prompt a bit. I don't expect a merge or anything but wanted to share this as a possible inspiration for others.

> A side note is that it seems to me that most prompts hardcode a lot of decisions into their source codes, which makes forking the only way to customize them. I have a very limited knowledge of shell scripting and was in awe looking at the source code of this prompt, almost none of which I understood, but it would be great, IMO, if I could easily specify the left/right location of various pieces of info, whether to include them at all, etc.

The forked prompt with some slight color customization (`AGKOZAK_COLORS_BRANCH_STATUS=243`) looks like this:

![image](https://user-images.githubusercontent.com/101152/42414468-23807350-8236-11e8-9c89-862c07d073a1.png)
