### PR TITLE
Removed explicit declaration for variable 'k'

### DIFF
--- a/agkozak-zsh-prompt.plugin.zsh
+++ b/agkozak-zsh-prompt.plugin.zsh
@@ -266,7 +266,7 @@ _agkozak_branch_status() {
   branch=${ref#refs/heads/}
 
   if [[ -n $branch ]]; then
-    local git_status symbols i=1 k
+    local git_status symbols i=1
     git_status="$(LC_ALL=C command git status 2>&1)"
 
     typeset -A messages


### PR DESCRIPTION
'k' was implicitly declared in the for loop, and isn't used outside of it. I noticed this while making some modifications to an offline copy of the theme, so I decided to open a PR.