### PR TITLE
git --no-optional-locks status

### DIFF
--- a/agkozak-zsh-prompt.plugin.zsh
+++ b/agkozak-zsh-prompt.plugin.zsh
@@ -267,7 +267,7 @@ _agkozak_branch_status() {
 
   if [[ -n $branch ]]; then
     local git_status symbols i=1 k
-    git_status="$(LC_ALL=C command git status 2>&1)"
+    git_status="$(LC_ALL=C command git --no-optional-locks status 2>&1)"
 
     typeset -A messages
     messages=(


### PR DESCRIPTION
First, let me mention that your prompt theme is awesome!  I'm impressed with both the choices and the configurability, which made it very easy to get into a form I liked.  Onto the PR:

`git status` introduced a command-line option [--no-optional-locks](https://github.com/git/git/commit/27344d6a6c8056664966e11acf674e5da6dd7ee3) exactly intended for background calls to git status that doesn't lock or change any index files.  Without this option, just calling `git status` can update the index file, often even when nothing has changed.

In my environment (files synchronized via Unison), it's pretty annoying for my shell's prompt to be changing files underneath me without any action beyond `cd`.  Hopefully this is a non-controversial change for everyone.