### PR TITLE
Add an indicator for stashed changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Deleted | x
 Modified | !
 Renamed | >
 Untracked | ?
+Stashed Changes | $
 
 ## Exit Status
 
@@ -283,11 +284,11 @@ Note that you could change one of those `%F{magenta}...%f` strings to another fo
 
 If, through the use of another prompt, your muscle memory has been trained to react immediately to a particular set of Git status symbols, or if you have an aesthetic preference for symbols other than the default ASCII ones, you may specify them in the array `AGKOZAK_CUSTOM_SYMBOLS`. The default set is
 
-    AGKOZAK_CUSTOM_SYMBOLS=( '&*' '&' '*' '+' 'x' '!' '>' '?' )
+    AGKOZAK_CUSTOM_SYMBOLS=( '&*' '&' '*' '+' 'x' '!' '>' '?' '$')
 
 If you prefer the [pure](https://github.com/sindresorhus/pure) symbols for the "diverged," "behind," and "ahead" states, you could use the following settings:
 
-    AGKOZAK_CUSTOM_SYMBOLS=( '⇣⇡' '⇣' '⇡' '+' 'x' '!' '>' '?' )
+    AGKOZAK_CUSTOM_SYMBOLS=( '⇣⇡' '⇣' '⇡' '+' 'x' '!' '>' '?' 'S')
 
 ### Other Settings
 

--- a/agkozak-zsh-prompt.plugin.zsh
+++ b/agkozak-zsh-prompt.plugin.zsh
@@ -297,6 +297,12 @@ _agkozak_branch_status() {
       (( i++ ))
     done
 
+    # Check for stashed changes. If this is the case add the respective
+    # stash symbol to the list of symbols.
+    if $(command git rev-parse --verify refs/stash >/dev/null 2>&1); then
+      symbols+="${AGKOZAK_CUSTOM_SYMBOLS[$i]:-\$}"
+    fi
+
     [[ -n $symbols ]] && symbols=" ${symbols}"
 
     printf '%s(%s%s)' "${AGKOZAK_BRANCH_STATUS_SEPARATOR- }" "$branch" "$symbols"


### PR DESCRIPTION
I switched from the [spaceship-prompt](https://github.com/denysdovhan/spaceship-prompt) to the agkozak-zsh-prompt recently, and I really like it. So first of all: thank you for the prompt :smile:.
 
However there is a feature in the spaceship-prompt I found really useful. It adds an indicator if there are stashed changes. I occasionally forget that I stashed some changes and therefore find this feature a great help. This PR introduces the indicator for stashed changes to the agkozak zsh prompt. I hope you find it as useful as I do. Otherwise, feel free to reject the PR.

Unfortunately I'm not an experienced ZSH programmer. I'm especially unsure whether the way I use the `$` sign as the default if nothing else is set is the correct way to do it.