### PR TITLE
Add variable AGKOZAK_PROMPT_DIRTRIM_CHAR (default: '...')

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ This prompt has been tested on numerous Linux and BSD distributions, as well as 
 <details>
   <summary>Here are the latest features and updates.</summary>
 
+- Unreleased
+    - The characters used as ellipsis with `AGKOZAK_PROMPT_DIRTRIM` (`...` by default) can now be overridden by setting `AGKOZAK_PROMPT_DIRTRIM_CHAR`.
 - v3.8 (July 9, 2020)
     - The prompt no longer defaults to `zsh-async` on Solaris and Solaris-derived operating systems, as I have noticed that `zsh-async`'s performance can be quirky on underperforming systems.
 - v3.7.3 (May 14, 2020)
@@ -208,6 +210,8 @@ is displayed as
 ![.../sense-hat/examples](img/abbreviated_paths_2.png)
 
 that is, without a tilde.
+
+Setting `AGKOZAK_PROMPT_DIRTRIM_CHAR` will override the default `...` string used for the ellipsis.
 
 If you would like to display a different number of directory elements, set the environment variable `AGKOZAK_PROMPT_DIRTRIM` in your `.zshrc` file thus (as in the example below):
 
@@ -412,13 +416,13 @@ Now that the right prompt no longer does anything, you could use the `AGKOZAK_CU
 So far, you will have used only the following code:
 
     AGKOZAK_LEFT_PROMPT_ONLY=1
-    AGKOZAK_COLORS_BRANCH_STATUS=243 
+    AGKOZAK_COLORS_BRANCH_STATUS=243
     AGKOZAK_CUSTOM_RPROMPT='%*'
 
 The same result could be achieved by starting with the default code given at the top of this section and altering it to produce
 
 ```sh
-# Exit status 
+# Exit status
 AGKOZAK_CUSTOM_PROMPT='%(?..%B%F{red}(%?%)%f%b )'
 # Command execution time
 AGKOZAK_CUSTOM_PROMPT+='%(9V.%9v .)'
@@ -688,6 +692,7 @@ Option | Default | Meaning
 [`AGKOZAK_PRE_PROMPT_CHAR`](#optional-single-line-prompt) | ` ` | For a single-line prompt, the character or characters to display before the prompt character
 [`AGKOZAK_PROMPT_DEBUG`](#asynchronous-methods) | `0` | Show debugging information
 [`AGKOZAK_PROMPT_DIRTRIM`](#abbreviated-paths) | `2` | Number of directory elements to display; `0` turns off directory trimming
+[`AGKOZAK_PROMPT_DIRTRIM_CHAR`](#abbreviated-paths) | `...` | Character or characters used as ellipsis when directory trimming
 [`AGKOZAK_SHOW_STASH`](#agkozak_show_stash) | `1` | Display stashed changes
 [`AGKOZAK_SHOW_VIRTUALENV`](#virtual-environments) | `1` | Display virtual environments
 [`AGKOZAK_USER_HOST_DISPLAY`](#agkozak_user_host_display) | `1` | Display the username and hostname

--- a/agkozak-zsh-prompt.plugin.zsh
+++ b/agkozak-zsh-prompt.plugin.zsh
@@ -198,6 +198,8 @@ fi
 : ${AGKOZAK_NAMED_DIRS:=1}
 # The number of path elements to display (default: 2; 0 displays the whole path)
 : ${AGKOZAK_PROMPT_DIRTRIM:=2}
+# The ellipsis string to use when trimming paths (default: ...)
+: ${AGKOZAK_PROMPT_DIRTRIM_CHAR=...}
 # Whether or not to display the Git stash (default: on)
 : ${AGKOZAK_SHOW_STASH:=1}
 # Whether or not to display the username and hostname (default: on)
@@ -256,7 +258,8 @@ _agkozak_is_ssh() {
 # has more than a certain number of elements in its
 # directory tree, keep the number specified by
 # AGKOZAK_PROMPT_DIRTRIM (default: 2) and abbreviate the
-# rest with `...'. (Set AGKOZAK_PROMPT_DIRTRIM=0 to disable
+# rest with AGKOZAK_PROMPT_DIRTRIM_CHAR (default: `...').
+# (Set AGKOZAK_PROMPT_DIRTRIM=0 to disable
 # directory trimming). For example,
 #
 #   $HOME/dotfiles/polyglot/img
@@ -277,6 +280,7 @@ _agkozak_is_ssh() {
 #   $1 [Optional] If `-v', store the function's output in
 #        psvar[2] instead of printing it to STDOUT
 #   $2 Number of directory elements to display (default: 2)
+#   $3 Ellipsis string (default: ...)
 ############################################################
 _agkozak_prompt_dirtrim() {
   emulate -L zsh
@@ -303,9 +307,9 @@ _agkozak_prompt_dirtrim() {
     if (( $1 )); then
       case $zsh_pwd in
         \~) output=${(%)zsh_pwd} ;;
-        \~/*) output="${(%):-%($(( $1 + 2 ))~|~/.../%${1}~|%~)}" ;;
-        \~*) output="${(%):-%($(( $1 + 2 ))~|${zsh_pwd%%${zsh_pwd#\~*\/}}.../%${1}~|%~)}" ;;
-        *) output="${(%):-%($(( $1 + 1 ))/|.../%${1}d|%d)}" ;;
+        \~/*) output="${(%):-%($(( $1 + 2 ))~|~/${2}/%${1}~|%~)}" ;;
+        \~*) output="${(%):-%($(( $1 + 2 ))~|${zsh_pwd%%${zsh_pwd#\~*\/}}${2}/%${1}~|%~)}" ;;
+        *) output="${(%):-%($(( $1 + 1 ))/|${2}/%${1}d|%d)}" ;;
       esac
     else
       output=$zsh_pwd
@@ -339,8 +343,8 @@ _agkozak_prompt_dirtrim() {
           (( i++ ))
         done
         case $PWD in
-          ${HOME}*) output="~/...${dir#${lopped_path}}" ;;
-          *) output="...${PWD#${lopped_path}}" ;;
+          ${HOME}*) output="~/${2}${dir#${lopped_path}}" ;;
+          *) output="${2}${PWD#${lopped_path}}" ;;
         esac
       fi
 
@@ -813,6 +817,7 @@ _agkozak_preexec() {
 #   AGKOZAK_PRE_PROMPT_CHAR
 #   AGKOZAK_BLANK_LINES
 #   AGKOZAK_PROMPT_DIRTRIM
+#   AGKOZAK_PROMPT_DIRTRIM_CHAR
 ############################################################
 _agkozak_precmd() {
   emulate -L zsh
@@ -900,7 +905,7 @@ _agkozak_precmd() {
   esac
 
   # Construct and display PROMPT and RPROMPT
-  _agkozak_prompt_dirtrim -v ${AGKOZAK_PROMPT_DIRTRIM:-2}
+  _agkozak_prompt_dirtrim -v ${AGKOZAK_PROMPT_DIRTRIM:-2} ${AGKOZAK_PROMPT_DIRTRIM_CHAR-...}
   _agkozak_prompt_strings
 }
 
@@ -974,6 +979,7 @@ _agkozak_prompt_strings() {
 #   AGKOZAK
 #   AGKOZAK_PROMPT_DEBUG
 #   AGKOZAK_PROMPT_DIRTRIM
+#   AGKOZAK_PROMPT_DIRTRIM_CHAR
 ############################################################
 agkozak-zsh-prompt() {
   emulate -L zsh
@@ -1018,7 +1024,7 @@ agkozak-zsh-prompt() {
   if [[ $TERM == 'dumb' ]]; then
     PROMPT='%(?..(%?%) )'
     PROMPT+='%n%1v '
-    PROMPT+='$(_agkozak_prompt_dirtrim "${AGKOZAK_PROMPT_DIRTRIM:-2}")'
+    PROMPT+='$(_agkozak_prompt_dirtrim "${AGKOZAK_PROMPT_DIRTRIM:-2}" "${AGKOZAK_PROMPT_DIRTRIM_CHAR-...}")'
     PROMPT+='$(_agkozak_branch_status) '
     PROMPT+='%# '
   else


### PR DESCRIPTION
_agkozak_prompt_dirtrim now takes this value as argument 3 (second mandatory argument)

Add variable with default value to the environment (if unset)

Update docs in comments accordingly

Functions using the new global variable now include an annotation saying as much

NOTE: The default _can_ be overridden with an empty string value;
default value '...' is only used when the variable is _unset_

README:

- Add note to Abbreviated Paths
- Add entry in configuration variable table
- Add note to new 'Unreleased' pseudo-version at top of News